### PR TITLE
Update testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,7 @@ python:
     - 2.7
 sudo: false
 install:
-    - travis_retry pip install ipython nose coveralls
+    - travis_retry pip install ipython nose requests
     - python setup.py develop
 script:
-    - cd /tmp && iptest ipyext --coverage xml && cd -
-after_success:
-    - cp /tmp/ipy_coverage.xml ./
-    - cp /tmp/.coverage ./
-    - coveralls
+    - python test.py

--- a/ipyext/tests/test_inactive.py
+++ b/ipyext/tests/test_inactive.py
@@ -29,7 +29,7 @@ def test_time():
     ip = get_ipython() 
     
     with tt.AssertPrints("'inactive' magic loaded"):
-        ip.run_cell("%load_ext ipyext.inactive")
+        ip.run_cell("%reload_ext ipyext.inactive")
     
     with tt.AssertPrints("Cell inactive: not executed!"):
         with tt.AssertNotPrints("code not run", suppress=False):

--- a/test.py
+++ b/test.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+
+"""
+Small wrapper around IPythons testing runner
+
+It calls iptest with 'ipyext' as testgroup. You can pass
+arguments to nose by appending them after '--'
+"""
+from __future__ import print_function
+
+from IPython.testing.iptestcontroller import main
+import sys
+
+if '--coverage' in sys.argv:
+    print("Coverage will not see any data (because tests work via ipythons '.run_cell()'?)")
+
+# add our testgroup at the beginning of the arguments to iptest
+sys.argv[1:1] = ["ipyext"]
+
+main()


### PR DESCRIPTION
The latest IPython conda package does not include "iptest", so
include a small wrapper. Call as "python test.py"...

Remove coverage from travis, as the way we test magics seem to
prevent that coverage "sees" this usage and therefore does not
give any coverage data for ipyext :-(

Also restructure the travis tests to work with the new testing
script -> no need to switch to a temp dir and therfore also no
need to install the package.
