### PR TITLE
Make conf.py work on RTD

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,14 +26,13 @@ if ON_RTD:
     tags.add('rtd')
 
     # RTD doesn't use the Makefile, so re-run autogen_{things}.py here.
-    for name in ('magics'):
-        fname = 'autogen_{}.py'.format(name)
-        fpath = os.path.abspath(os.path.join('..', fname))
-        with open(fpath) as f:
-            exec(compile(f.read(), fname, 'exec'), {
-                '__file__': fpath,
-                '__name__': '__main__',
-            })
+    fname = 'autogen_magics.py'
+    fpath = os.path.abspath(os.path.join('..', fname))
+    with open(fpath) as f:
+        exec(compile(f.read(), fname, 'exec'), {
+            '__file__': fpath,
+            '__name__': '__main__',
+        })
 
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it


### PR DESCRIPTION
I've tried this in my own RTD account for this repo, but it would be nice if someone could setup RTD for the main repo:
- Import the repo in the account
- under advanced settings -> check "Install your project inside a virtualenv using setup.py install" & add a "docs/requirements.txt" as a doc requirement & make it python3.x 
