### PR TITLE
Update install instruction for conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This package consists of various IPython extensions (mostly new %magics). It exists mainly to make installation of these extension easier: you only need to install and update one package to get multiple extensions. Also, the up-to-now used `%install_ext` magic is [deprecated and will be removed in a future version](https://github.com/ipython/ipython/pull/8763), so the only way to distribute extensions is via python packages.
 
+## Installation
+
+With pip:
+
+```
+pip install ipyext
+```
+
+With conda: 
+
+```
+conda install -c https://conda.anaconda.org/janschulz ipyext
+```
+
 ## Documentation
 
 The documentation can be found on http://ipython-extensions.readthedocs.org/en/latest/
@@ -10,7 +24,7 @@ The documentation can be found on http://ipython-extensions.readthedocs.org/en/l
 
 You have an IPython extension (e.g. a `%magic` command) but it's too small to build your own package? You are welcome to contribute it to this repository!
 
-To prevent bit rot, it should follow the guidelines outlined in [CONTRIBUTING.md](CONTRIBUTING.md), meaning:
+To prevent bit rot, it should follow the guidelines outlined in [CONTRIBUTING.md](https://github.com/ipython-contrib/IPython-extensions/blob/master/CONTRIBUTING.md), meaning:
 
 * it should be IPython centric (notebook centric extensions belong to the [jupyter notebook extension repo](https://github.com/ipython-contrib/IPython-notebook-extensions))
 * it should have proper documentation (preferable in [numpydoc style](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt))

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -18,11 +18,17 @@ Quickstart
 ----------
 
 If you have :mod:`pip`,
-the quickest way to get up and running with IPython is:
+the quickest way to get up and running with IPython-extensions is:
 
 .. code-block:: bash
 
     $ pip install ipyext
+    
+If you use `conda`, you can also install with
+
+.. code-block:: bash
+
+    $ conda install -c https://conda.anaconda.org/janschulz ipyext
 
 
 Installing the development version


### PR DESCRIPTION
Now we have conda packages in https://anaconda.org/janschulz/ipyext
