### PR TITLE
New Demo Mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     - 2.7
 sudo: false
 install:
-    - travis_retry pip install ipython nose requests
+    - travis_retry pip install ipython nose requests mock
     - python setup.py develop
 script:
     - python test.py

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -59,10 +59,7 @@ dist: html
 	cp -al build/html .
 	@echo "Build finished.  Final docs are in html/"
 
-html: api autoconfig automagic
-html_noapi: clean_api autoconfig automagic
-
-html html_noapi:
+html html_noapi: automagic
 	mkdir -p build/html build/doctrees
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html
 	@echo
@@ -73,18 +70,6 @@ automagic: source/interactive/magics-generated.txt
 source/interactive/magics-generated.txt: autogen_magics.py
 	python autogen_magics.py
 	@echo "Created docs for line & cell magics"
-
-autoconfig: source/config/options/generated
-
-source/config/options/generated:
-	python autogen_config.py
-	@echo "Created docs for config options"
-
-api: source/api/generated/gen.txt
-
-source/api/generated/gen.txt:
-	python autogen_api.py
-	@echo "Build API docs finished."
 
 pickle:
 	mkdir -p build/pickle build/doctrees

--- a/docs/autogen_magics.py
+++ b/docs/autogen_magics.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from IPython.core.alias import Alias
 from IPython.core.interactiveshell import InteractiveShell
@@ -15,6 +16,9 @@ for name, func in magics['line'].items():
     ipy_magics.append(name)
 for name, func in magics['cell'].items():
     ipy_magics.append(name)
+
+# put the package itself into the path so we can run the build without installing
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from ipyext import all_class_magics
 shell.register_magics(*all_class_magics)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,9 @@ if ON_RTD:
 # absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../sphinxext'))
 
+# put the package itself into the path so we can run the build without installing
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
 # We load the ipython release info into a dict by explicit execution
 ipextrelease = {}
 exec(compile(open('../../ipyext/_version.py').read(), '../../ipyext/_version.py', 'exec'),ipextrelease)
@@ -69,6 +72,8 @@ if ON_RTD:
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
+
+autosummary_generate = True
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/docs/source/demo_mode.rst
+++ b/docs/source/demo_mode.rst
@@ -7,18 +7,81 @@ Demo mode
 
 .. currentmodule:: ipyext.demo
 
+As a User
+---------
+
+There are currently two possible sources of demos:
+
+* plain (self contained) functions included in modules
+  of libraries you use.
+* the matplotlib examples in their github repository
+
+``demo(...)`` has two modes:
+
+* for a imported module or a directory on github, it will list the available demos.
+* for a function or a file on github, it will show the demo.
+
+Example:
+
 .. ipython:: python
-    
+
     from ipyext.demo import demo
     import ipyext.demo
-    demo(ipyext.demo)
-    demo("<gh_matplotlib>/statistics/")
-    # stops an already running demo
-    demo("STOP")
+    demo(ipyext.demo) # lists all demos
+    demo(ipyext.demo.demo_example) # runs the demo_example
+    demo("STOP") # stops an already running demo
+    demo("<gh_matplotlib>/statistics/") # lists demos from matplotlibs' examples
 
+
+Hiere is the API documentation of ``demo()``
 
 .. autosummary::
    :toctree: generated/
 
     demo
 
+As a developer
+--------------
+
+You can create demos by adding a new module which should contain two things:
+
+* One or more *self contained functions* which take *no arguments*. The
+  functions can have two types of *comments*: ``"# "`` (fence + space) are
+  interpreted as markdown (e.g. write ``"# # headline"``) and result in
+  markdown cells in the notebook and normal comments in the console.
+  Comments without a space are interpreted as code comments and added
+  directly to the following code input. You can add a *one line docstring*
+  which will be shown as description of the demo in the list of available
+  demos. Using *IPython magic methods* are also possible but must be
+  commented.
+* A ``__demos__`` field in the module which *lists all demo functions* (direct
+  reference, not strings like in ``__all__``!).
+
+Example:
+
+.. code-block:: python
+
+    def demo_example():
+        """An example how to write a demo."""
+        # ## Comments
+        # Comments are interpreted as markdown syntax, removing the
+        # initial `# `. If a comment starts only with `#`, it is interpreted
+        # as a code comment, which will end up together with the code.
+        #change your name:
+        name = "Jan"
+        print("Hello {0}!".format(name))
+        # ## Magics
+        # Using magics would result in not compiling code, so magics
+        # have to be commented out. The demo will remove the comment
+        # and insert it into the cell as code.
+        #%%time
+        _sum = 0
+        for x in range(10000):
+            _sum += x
+        # Print the sum:
+        print(_sum)
+
+    # This lets the `demo(ipyext.demo)` find only the `demo_example`.
+    # Only modues with that variable will display an overview of
+    # the available demos.
+    __demos__ = [demo_example]

--- a/docs/source/demo_mode.rst
+++ b/docs/source/demo_mode.rst
@@ -13,6 +13,8 @@ Demo mode
     import ipyext.demo
     demo(ipyext.demo)
     demo("<gh_matplotlib>/statistics/")
+    # stops an already running demo
+    demo("STOP")
 
 
 .. autosummary::

--- a/docs/source/demo_mode.rst
+++ b/docs/source/demo_mode.rst
@@ -1,0 +1,22 @@
+.. currentmodule:: ipyext
+.. _demo_mode:
+
+*************
+Demo mode
+*************
+
+.. currentmodule:: ipyext.demo
+
+.. ipython:: python
+    
+    from ipyext.demo import demo
+    import ipyext.demo
+    demo(ipyext.demo)
+    demo("<gh_matplotlib>/statistics/")
+
+
+.. autosummary::
+   :toctree: generated/
+
+    demo
+

--- a/docs/source/generated/ipyext.demo.demo.rst
+++ b/docs/source/generated/ipyext.demo.demo.rst
@@ -1,0 +1,6 @@
+ipyext.demo.demo
+================
+
+.. currentmodule:: ipyext.demo
+
+.. autofunction:: demo

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ Contents
 
    install
    magics
+   demo_mode
    whatsnew
 
 .. seealso::

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -2,11 +2,17 @@
 What's new in IPython-extensions
 ================================
 
-This section documents the changes that have been made in various 
-versions of IPython-extensions. Users should consult these pages to 
-learn about new features, bug fixes and backwards incompatibilities. 
-Developers should summarize the development work they do here in a user 
-friendly format. 
+This section documents the changes that have been made in various
+versions of IPython-extensions. Users should consult these pages to
+learn about new features, bug fixes and backwards incompatibilities.
+Developers should summarize the development work they do here in a user
+friendly format.
+
+Dev 0.2.0 (current development)
+===============================
+
+* New ``demo()`` command
+
 
 Release 0.1.0
 =============

--- a/ipyext/demo.py
+++ b/ipyext/demo.py
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 from __future__ import division, print_function, absolute_import
 
-__all__ = ["notebook_demo"]
+__all__ = ["demo"]
 
 import inspect
 from textwrap import dedent
@@ -32,7 +32,7 @@ else:
     text_type = unicode
     binary_type = str
 
-def notebook_demo(content, frontend=None):
+def demo(content, frontend=None):
     """Run a demo or view all available demos.
     Parameters
     ----------
@@ -46,11 +46,18 @@ def notebook_demo(content, frontend=None):
     """
     if frontend is None:
         frontend = NotebookFrontend()
+    elif frontend == "ipython":
+        frontend = IPythonFrontend()
 
-    if isinstance(content, string_types):
-        backend = GithubURLBackend()
-    else:
-        backend = PythonCodeBackend()
+    if content == "STOP":
+        frontend.abbort()
+        return
+
+    backend = None
+    for be in [GithubURLBackend, PythonCodeBackend]:
+        cand = be()
+        if cand.can_handle(content):
+            backend = cand
     try:
         type, content = backend.get(content)
     except Exception as e:
@@ -127,7 +134,7 @@ _URLS_GITHUBURLBACKEND = {
                   '/examples/{0}'
 }
 
-_RE_GITHUBURLBACKEND = re.compile(r"^<gh_(.*)>/.*")
+_RE_GITHUBURLBACKEND = re.compile(r"^<gh_.*>.*")
 class GithubURLBackend(Backend):
 
     def can_handle(self, content):
@@ -139,6 +146,9 @@ class GithubURLBackend(Backend):
     def get(self, content):
         import requests
         typ = "cells" if content.endswith(".py") else "toc"
+        # add a trailing slash
+        if content[-1:] != "/":
+            content = content + "/"
         name = content
         content = content.split("/")
         # get the base source for the demo, which is the first element minus the <gh_.*> stuff
@@ -166,9 +176,9 @@ class GithubURLBackend(Backend):
             #print(ret)
             files = [item for item in ret if item['type'] == 'file']
             dirs = [item for item in ret if item['type'] == 'dir']
-            demo_names = [name+"/"+item["name"] for item in files]
+            demo_names = [name+item["name"] for item in files]
             demos = [(name, "") for name in demo_names if name.endswith(".py")]
-            dir_names = [name+"/"+item["name"] for item in dirs]
+            dir_names = [name+item["name"] for item in dirs]
             more_demos = [(name, "[directory}") for name in dir_names]
             return typ, (name, demos + more_demos)
         raise Exception("This should not happen...")
@@ -181,6 +191,10 @@ class Frontend(object):
 
     def _build(self, cells):
         """Builds the to be published content from the cells"""
+        raise NotImplementedError
+
+    def abbort(self):
+        """Stops a already running demo, if not already published in full"""
         raise NotImplementedError
 
     def insert_demo(self, cells):
@@ -198,11 +212,91 @@ class Frontend(object):
         print(msg.format(name, "\n".join(demos) ))
 
 
+class IPythonFrontend(Frontend):
+
+    # This is ententional a class atribute to also work as a sentinel if another demo is already
+    # running
+    _buffer = []
+
+    def __init__(self):
+        if self._buffer:
+            raise Exception("Already in a running demo, abort with 'demo(\"STOP\")'")
+        try:
+            self.ip = get_ipython()
+            self._orig_run_cell = self.ip.run_cell
+        except:
+            raise Exception("Not running in a IPython environment")
+
+    def abbort(self):
+        """Stops a already running demo, if not already published in full"""
+        if not self._buffer:
+            print("Not in a demo, nothing to stop!")
+            return
+        while self._buffer:
+            self._buffer.pop(0)
+        # deinstall the wrapper
+        self.ip.run_cell = self._orig_run_cell
+        print("Demo stopped!")
+
+    def _publish(self):
+        """Publishes the content of the demo to the frontend"""
+        that = self
+        def run_cell_wrapper(*args, **kwargs):
+            if not that._buffer:
+                # Failsave if the wrapper wasn't deinstalled
+                that.ip.run_cell = that._orig_run_cell
+            # run current code
+            that._orig_run_cell(*args, **kwargs)
+            # set next input to the next code in buffer
+            if that._buffer:
+                code = that._buffer.pop(0)
+                that.ip.set_next_input(code, replace=False)
+            else:
+                # deinstall the wrapper if the buffer is empty
+                that.ip.run_cell = that._orig_run_cell
+
+
+        self.ip.run_cell = run_cell_wrapper
+        code = self._buffer.pop(0)
+        self.ip.set_next_input(code, replace=False)
+
+
+    def _build(self, cells):
+        """In this case just fills a buffer"""
+        md_buffer = None
+        for cell in cells:
+            source = cell['source'].strip()
+            if cell['cell_type'] == 'markdown':
+                lines = source.split("\n")
+                lines = ["# " + line for line in lines]
+                #lines.append("pass # do not remove") # to make even comment only cells to run
+                # something
+                commented = "\n".join(lines)
+                md_buffer = commented
+            elif cell['cell_type'] == 'code':
+                if md_buffer is not None:
+                    # cell magics need to be at the start of a cell
+                    if source[0:2] == "%%":
+                        self._buffer.append(md_buffer)
+                    else:
+                        source = md_buffer + "\n" + source
+                    md_buffer = None
+                self._buffer.append(source)
+        if md_buffer is not None:
+            self._buffer.append(md_buffer)
+
+
+
+
 # Adapted from https://github.com/jupyter-incubator/contentmanagement/blob/master/urth/cms/inject.py
 class NotebookFrontend(Frontend):
 
     def __init__(self):
         self._js = []
+
+    def abbort(self):
+        """Stops a already running demo, if not already published in full"""
+        print("Full demo already visible, please just delete all cells")
 
     def _publish(self):
         """Publishes the content of the demo to the frontend"""

--- a/ipyext/demo.py
+++ b/ipyext/demo.py
@@ -1,0 +1,303 @@
+# encoding: utf-8
+
+# Copyright (c) IPython-extensions Development Team.
+# Distributed under the terms of the Modified BSD License.
+from __future__ import division, print_function, absolute_import
+
+__all__ = ["notebook_demo"]
+
+import inspect
+from textwrap import dedent
+import re
+import sys
+
+try:
+    #py3
+    from base64 import decodebytes
+except ImportError:
+    # py2
+    from base64 import decodestring as decodebytes
+
+
+# True if we are running on Python 3.
+PY3 = sys.version_info[0] == 3
+
+if PY3: # pragma: no cover
+    string_types = (str,),
+    text_type = str
+    binary_type = bytes
+    long = int
+else:
+    string_types = (str, unicode),
+    text_type = unicode
+    binary_type = str
+
+def notebook_demo(content, frontend=None):
+    """Run a demo or view all available demos.
+    Parameters
+    ----------
+    content : whatever content should be displayed as a demo source
+        Examples include a passed in function or module or a path on github in the form
+        ``"<gh_project>/path/to/demo.py"`` (where project is a known project which provides demos
+        on github)
+    frontend : Frontend instace (optional, default is NotebookFrontend)
+        A frontend, which should display the demo (currently only used for testing purpose)
+
+    """
+    if frontend is None:
+        frontend = NotebookFrontend()
+
+    if isinstance(content, string_types):
+        backend = GithubURLBackend()
+    else:
+        backend = PythonCodeBackend()
+    try:
+        type, content = backend.get(content)
+    except Exception as e:
+        print(e.args)
+        return
+
+    if type == "toc":
+        name, toc = content
+        frontend.display_toc(name, toc)
+    elif type == "cells":
+        frontend.insert_demo(content)
+
+
+class Backend(object):
+    def can_handle(self, content):
+        """
+        Parameters
+        ----------
+        content : Whatever input demo got
+           The content which should be used as the demo source
+
+        Returns
+        -------
+        Bool : whether or not this backend can handle the content
+        """
+        raise NotImplementedError
+
+    def get(self, content):
+        """Gets content from the backend.
+
+        Parameters
+        ----------
+        content : Whatever input demo got and we can handle
+           The content which should be used as the demo source
+
+        Returns
+        -------
+        (type, content) : the type and real content for this content
+            ``type`` is one of "toc" or "cells". ``content`` is a list of tuples ``(name,
+            description)`` which should be displayed as available demos (if ``type=="toc"``) or
+            a a list of ``cells`` which should be displayed.
+        """
+        raise NotImplementedError
+
+class PythonCodeBackend(Backend):
+
+    def can_handle(self, content):
+        if inspect.ismodule(content) or inspect.isfunction(content):
+            return True
+        return False
+
+    def get(self, content):
+        if inspect.ismodule(content):
+            if hasattr(content, "__demos__"):
+                name = content.__name__
+                demos = content.__demos__
+                toc =  [(d.__name__, d.__doc__) for d in demos]
+                return "toc", (name, toc)
+            else:
+                msg = "The module {0} has no demos available."
+                raise Exception(msg.format(content.__name__))
+        elif not inspect.isfunction(content):
+            msg = "Not a module or a function: {0}"
+            raise Exception(msg.format(content))
+        else:
+            # we have a function...
+            # TODO: make sure that the function takes no argument
+
+            source = inspect.getsource(content)
+            return "cells", _function_source_to_cells(source)
+
+_URLS_GITHUBURLBACKEND = {
+    "matplotlib": 'https://api.github.com/repos/matplotlib/matplotlib/contents'
+                  '/examples/{0}'
+}
+
+_RE_GITHUBURLBACKEND = re.compile(r"^<gh_(.*)>/.*")
+class GithubURLBackend(Backend):
+
+    def can_handle(self, content):
+        if isinstance(content, string_types):
+            if _RE_GITHUBURLBACKEND.search(content) is not None:
+                return True
+        return False
+
+    def get(self, content):
+        import requests
+        typ = "cells" if content.endswith(".py") else "toc"
+        name = content
+        content = content.split("/")
+        # get the base source for the demo, which is the first element minus the <gh_.*> stuff
+        demo_source = content[0][4:-1]
+        if demo_source not in _URLS_GITHUBURLBACKEND:
+            raise Exception("Unknown github demo source: {0}".format(demo_source))
+        base_url = _URLS_GITHUBURLBACKEND[demo_source]
+        path = "/".join(content[1:])
+        headers = {"accept": "application/vnd.github.v3.json"}
+        url = base_url.format(path)
+        #print(url)
+        r = requests.get(url, headers=headers)
+        ret = r.json()
+        # unauthenticated requests have a ratelimit...
+        if 'message' in ret:
+            raise Exception(ret['message'])
+        if typ == "cells":
+            content = ret["content"]
+            content = decodebytes(content.encode())
+            content = content.decode()
+            # Todo: split into cells?
+            return typ, [{"source": content, "cell_type":"code"}]
+        elif typ == "toc":
+            #ret = ret[0]
+            #print(ret)
+            files = [item for item in ret if item['type'] == 'file']
+            dirs = [item for item in ret if item['type'] == 'dir']
+            demo_names = [name+"/"+item["name"] for item in files]
+            demos = [(name, "") for name in demo_names if name.endswith(".py")]
+            dir_names = [name+"/"+item["name"] for item in dirs]
+            more_demos = [(name, "[directory}") for name in dir_names]
+            return typ, (name, demos + more_demos)
+        raise Exception("This should not happen...")
+
+class Frontend(object):
+
+    def _publish(self):
+        """Publishes the content of the demo to the frontend"""
+        raise NotImplementedError
+
+    def _build(self, cells):
+        """Builds the to be published content from the cells"""
+        raise NotImplementedError
+
+    def insert_demo(self, cells):
+        self._build(cells)
+        self._publish()
+
+    def display_toc(self, name, toc):
+        msg = """\
+        "{0}" has the following demo(s) available:
+
+        {1}
+        """
+        msg = dedent(msg)
+        demos = ["* {0}: {1}".format(d[0], d[1]) for d in toc]
+        print(msg.format(name, "\n".join(demos) ))
+
+
+# Adapted from https://github.com/jupyter-incubator/contentmanagement/blob/master/urth/cms/inject.py
+class NotebookFrontend(Frontend):
+
+    def __init__(self):
+        self._js = []
+
+    def _publish(self):
+        """Publishes the content of the demo to the frontend"""
+        from IPython.display import display, Javascript
+        display(Javascript("\n".join(self._js)))
+
+    def _build(self, cells):
+        '''
+        Creates a series of JS commands to inject code and markdown cells from
+        the passed notebook structure into the existing notebook sans output.
+        '''
+        import json
+        js = self._js
+        js += ['var i = IPython.notebook.get_selected_index();']
+        i = 0
+        for cell in cells:
+            if cell['cell_type'] == 'markdown':
+                js.append("var cell = IPython.notebook.insert_cell_below('markdown', i+{});".format(i))
+                escaped_source = json.dumps(cell['source'].strip()).strip('"')
+                js.append('cell.set_text("{}");'.format(escaped_source))
+                js.append('cell.rendered = false; cell.render();')
+                i += 1
+            elif cell['cell_type'] == 'code':
+                js.append("var cell = IPython.notebook.insert_cell_below('code', i+{});".format(i))
+                escaped_input = json.dumps(cell['source'].strip()).strip('"')
+                js.append('cell.set_text("{}");'.format(escaped_input))
+                i += 1
+
+        js.append('var self = this; setTimeout(function() { self.clear_output(); }, 0);')
+
+###################################################################################################
+#
+# Helper functions
+#
+###################################################################################################
+
+_RE_MAGICS = re.compile(r"^#%")
+_RE_MD = re.compile(r"^# ")
+
+def _function_source_to_cells(source):
+    lines = source.split("\n")
+    # remove the function declaration and the docstring
+    lines = lines[2:]
+    source = "\n".join(lines)
+    # remove whitespace as needed ans split again...
+    source = dedent(source)
+
+    lines = source.split("\n")
+
+    # convert commented magics to life magics
+    lines = [_RE_MAGICS.sub("%", line) for line in lines]
+    # identify markdown lines
+    lines = [("markdown" if _RE_MD.search(line) else "code", _RE_MD.sub("", line))
+                   for line in lines]
+    # ... and convert to "cell" contents
+    cells = []
+    state = None
+    buffer = []
+    for typ, line in lines + [("END", "")]:
+        if buffer and typ != state:
+            cell = {
+                "source": "\n".join(buffer),
+                "cell_type": state
+                     }
+            cells.append(cell)
+            buffer = []
+        state = typ
+        buffer.append(line)
+    # Intentionally leave the buffer full with the last "END" state
+    return cells
+
+
+###################################################################################################
+#
+# Now starts the demo of a demo :-)
+#
+###################################################################################################
+
+def demo_example():
+    """An example how to write a demo."""
+    # ## Comments
+    # Comments are interpreted as markdown syntax, removing the initial `# `.
+    # If a comment starts only as `#` it is interpreted as a comment, which will
+    # end up together with the code.
+    #change your name:
+    name = "Jan"
+    print("Hello {0}!".format(name))
+    # ## Magics
+    # Using magics would result in not compiling code, so magics have to be commented out.
+    # The demo will remove the comment and insert it into the cell as code.
+    #%%time
+    _sum = 0
+    for x in range(10000):
+        _sum += x
+    # Print the sum:
+    print(_sum)
+
+__demos__ = [demo_example]

--- a/ipyext/demo.py
+++ b/ipyext/demo.py
@@ -34,14 +34,52 @@ else:
 
 def demo(content, frontend=None):
     """Run a demo or view all available demos.
+
     Parameters
     ----------
     content : whatever content should be displayed as a demo source
-        Examples include a passed in function or module or a path on github in the form
-        ``"<gh_project>/path/to/demo.py"`` (where project is a known project which provides demos
-        on github)
+        Examples include a passed in function or module or a path on github
+        in the form ``"<gh_project>/path/to/demo.py"`` (where project is a
+        known project which provides demos on github)
     frontend : Frontend instace (optional, default is NotebookFrontend)
-        A frontend, which should display the demo (currently only used for testing purpose)
+        A frontend, which should display the demo (currently only used for
+        testing purpose)
+
+    Examples
+    --------
+    Run the demo of the demo:
+
+    >>> from ipyext.demo import demo; import ipyext.demo
+    >>> demo(ipyext.demo)
+    "ipyext.demo" has the following demo(s) available:
+    * demo_example: An example how to write a demo.
+
+    >>> # ipython is for teh console, for notebook simply omit
+    >>> demo(ipyext.demo.demo_example, frontend="ipython")
+    [... demo code appears as input -> just press enter to execute ...]
+
+    The following will load a demo from the matplotlib repository and
+    output it in new cells in a jupyter notebook:
+
+    >>> demo("<gh_matplotlib>/statistics/")
+    "<gh_matplotlib>/statistics/violinplot_demo.py" has the following demo(s) available:
+    * <gh_matplotlib>/statistics/boxplot_color_demo.py:
+    * <gh_matplotlib>/statistics/boxplot_demo.py:
+    * <gh_matplotlib>/statistics/boxplot_vs_violin_demo.py:
+    * <gh_matplotlib>/statistics/bxp_demo.py:
+    * <gh_matplotlib>/statistics/errorbar_demo.py:
+    * <gh_matplotlib>/statistics/errorbar_demo_features.py:
+    * <gh_matplotlib>/statistics/errorbar_limits.py:
+    * <gh_matplotlib>/statistics/histogram_demo_cumulative.py:
+    * <gh_matplotlib>/statistics/histogram_demo_features.py:
+    * <gh_matplotlib>/statistics/histogram_demo_histtypes.py:
+    * <gh_matplotlib>/statistics/histogram_demo_multihist.py:
+    * <gh_matplotlib>/statistics/multiple_histograms_side_by_side.py:
+    * <gh_matplotlib>/statistics/violinplot_demo.py:
+
+    >>> demo("<gh_matplotlib>/statistics/histogram_demo_features.py")
+    [... demo code appears as new notebook cells which can be executed...]
+
 
     """
     if frontend is None:
@@ -208,7 +246,8 @@ class Frontend(object):
         {1}
         """
         msg = dedent(msg)
-        demos = ["* {0}: {1}".format(d[0], d[1]) for d in toc]
+        t_w, t_wo = "* {0}: {1}", "* {0}"
+        demos = [(t_w.format(d[0], d[1]) if d[1] else t_wo.format(d[0])) for d in toc]
         print(msg.format(name, "\n".join(demos) ))
 
 
@@ -341,7 +380,7 @@ def _function_source_to_cells(source):
     # remove the function declaration and the docstring
     lines = lines[2:]
     source = "\n".join(lines)
-    # remove whitespace as needed ans split again...
+    # remove whitespace as needed and split again...
     source = dedent(source)
 
     lines = source.split("\n")
@@ -375,18 +414,20 @@ def _function_source_to_cells(source):
 #
 ###################################################################################################
 
+
 def demo_example():
     """An example how to write a demo."""
     # ## Comments
-    # Comments are interpreted as markdown syntax, removing the initial `# `.
-    # If a comment starts only as `#` it is interpreted as a comment, which will
-    # end up together with the code.
+    # Comments are interpreted as markdown syntax, removing the
+    # initial `# `. If a comment starts only with `#`, it is interpreted
+    # as a code comment, which will end up together with the code.
     #change your name:
     name = "Jan"
     print("Hello {0}!".format(name))
     # ## Magics
-    # Using magics would result in not compiling code, so magics have to be commented out.
-    # The demo will remove the comment and insert it into the cell as code.
+    # Using magics would result in not compiling code, so magics
+    # have to be commented out. The demo will remove the comment
+    # and insert it into the cell as code.
     #%%time
     _sum = 0
     for x in range(10000):
@@ -394,4 +435,7 @@ def demo_example():
     # Print the sum:
     print(_sum)
 
+# This lets the `demo(ipyext.demo)` find only the `demo_example`.
+# Only modues with that variable will display an overview of
+# the available demos.
 __demos__ = [demo_example]

--- a/ipyext/demo.py
+++ b/ipyext/demo.py
@@ -59,7 +59,7 @@ def demo(content, frontend=None):
     "ipyext.demo" has the following demo(s) available:
     * demo_example: An example how to write a demo.
 
-    >>> # ipython is for teh console, for notebook simply omit
+    >>> # ipython is for the console, for notebook simply omit
     >>> demo(ipyext.demo.demo_example, frontend="ipython")
     [... demo code appears as input -> just press enter to execute ...]
 
@@ -380,12 +380,16 @@ class NotebookFrontend(Frontend):
     def _publish(self):
         """Publishes the content of the demo to the frontend"""
         from IPython.display import display, Javascript
-        display(Javascript("\n".join(self._js)))
+        class JavascriptWithFallback(Javascript):
+            def __repr__(self):
+                return ("Your frontend seems to be something else than the notebook. "
+                        "Please start the demo with 'demo(..., frontend=\"ipython\")'.")
+        display(JavascriptWithFallback("\n".join(self._js)))
 
     def _build(self, cells):
         '''
         Creates a series of JS commands to inject code and markdown cells from
-        the passed notebook structure into the existing notebook sans output.
+        the demo into the existing notebook.
         '''
         import json
         js = self._js
@@ -528,6 +532,6 @@ def demo_example():
     print(_sum)
 
 # This lets the `demo(ipyext.demo)` find only the `demo_example`.
-# Only modues with that variable will display an overview of
+# Only modules with that variable will display an overview of
 # the available demos.
 __demos__ = [demo_example]

--- a/ipyext/demo.py
+++ b/ipyext/demo.py
@@ -227,9 +227,9 @@ class GithubURLBackend(Backend):
             files = [item for item in ret if item['type'] == 'file']
             dirs = [item for item in ret if item['type'] == 'dir']
             demo_names = [name+item["name"] for item in files]
-            demos = [(name, "") for name in demo_names if name.endswith(".py")]
+            demos = [(dname, "") for dname in demo_names if dname.endswith(".py")]
             dir_names = [name+item["name"] for item in dirs]
-            more_demos = [(name, "[directory}") for name in dir_names]
+            more_demos = [(dir_name, "[directory}") for dir_name in dir_names]
             return typ, (name, demos + more_demos)
         raise Exception("This should not happen...")
 

--- a/ipyext/demo.py
+++ b/ipyext/demo.py
@@ -90,6 +90,14 @@ def demo(content, frontend=None):
         frontend = nb_frontend
     elif frontend == "ipython":
         frontend = ipy_frontend
+    elif frontend == "notebook":
+        frontend = nb_frontend
+    elif isinstance(frontend, Frontend):
+        # just use it...
+        pass
+    else:
+        print("Not a valid frontend: {}".format(frontend))
+        return
 
     if content == "STOP":
         for frontend in (nb_frontend, ipy_frontend):
@@ -107,7 +115,8 @@ def demo(content, frontend=None):
     try:
         type, content = backend.get(content)
     except Exception as e:
-        print(e.args)
+        print("Can't get the demo code:")
+        print("; ".join(e.args))
         return
 
     if type == "toc":
@@ -210,7 +219,7 @@ class GithubURLBackend(Backend):
         ret = r.json()
         # unauthenticated requests have a ratelimit...
         if 'message' in ret:
-            raise Exception(ret['message'])
+            raise Exception("Github: " + ret['message'])
         if typ == "cells":
             content = ret["content"]
             content = decodebytes(content.encode())
@@ -218,7 +227,7 @@ class GithubURLBackend(Backend):
             # Todo: split into cells?
             # splitting must depend on the frontend :-(
             # in the notebook, splititng matplotlib stuff results in multiple plots
-            # (also the plot.show() call shoudld be in teh same cell). It would be ok
+            # (also the plot.show() call shoudld be in the same cell). It would be ok
             # for the console...
             return typ, [{"source": content, "cell_type":"code"}]
         elif typ == "toc":
@@ -279,9 +288,8 @@ class IPythonFrontend(Frontend):
         self._buffer = []
         try:
             self.ip = get_ipython()
-            self._orig_run_cell = self.ip.run_cell
         except:
-            raise Exception("Not running in a IPython environment")
+            raise Exception("Not running in an IPython environment")
 
     def is_running(self):
         """Is the frontend currently running a demo?"""

--- a/ipyext/demo.py
+++ b/ipyext/demo.py
@@ -156,9 +156,10 @@ class Backend(object):
         Returns
         -------
         (type, content) : the type and real content for this content
-            ``type`` is one of "toc" or "cells". ``content`` is a list of tuples ``(name,
-            description)`` which should be displayed as available demos (if ``type=="toc"``) or
-            a a list of ``cells`` which should be displayed.
+            ``type`` is one of "toc" or "cells". ``content`` is a list of
+            tuples ``(name, description)`` which should be displayed as
+            available demos (if ``type=="toc"``) or a a list of ``cells`` which
+            should be displayed.
         """
         raise NotImplementedError
 
@@ -191,6 +192,8 @@ class PythonCodeBackend(Backend):
 
 _URLS_GITHUBURLBACKEND = {
     "matplotlib": 'https://api.github.com/repos/matplotlib/matplotlib/contents'
+                  '/examples/{0}',
+    "seaborn":    'https://api.github.com/repos/mwaskom/seaborn/contents'
                   '/examples/{0}'
 }
 

--- a/ipyext/demo.py
+++ b/ipyext/demo.py
@@ -208,6 +208,10 @@ class GithubURLBackend(Backend):
             content = decodebytes(content.encode())
             content = content.decode()
             # Todo: split into cells?
+            # splitting must depend on the frontend :-(
+            # in the notebook, splititng matplotlib stuff results in multiple plots
+            # (also the plot.show() call shoudld be in teh same cell). It would be ok
+            # for the console...
             return typ, [{"source": content, "cell_type":"code"}]
         elif typ == "toc":
             #ret = ret[0]
@@ -372,15 +376,21 @@ class NotebookFrontend(Frontend):
 #
 ###################################################################################################
 
-_RE_MAGICS = re.compile(r"^#%")
-_RE_MD = re.compile(r"^# ")
-
 def _function_source_to_cells(source):
+    # This assumes that function declaration is on one line and
+    # the docstring is also only one line
+    # TODO: parse that properly...
     lines = source.split("\n")
     # remove the function declaration and the docstring
     lines = lines[2:]
     source = "\n".join(lines)
-    # remove whitespace as needed and split again...
+    return _flat_source_to_cells(source)
+
+_RE_MAGICS = re.compile(r"^#%")
+_RE_MD = re.compile(r"^# ")
+
+def _flat_source_to_cells(source):
+    # remove whitespace as needed and split ...
     source = dedent(source)
 
     lines = source.split("\n")

--- a/ipyext/tests/test_demo.py
+++ b/ipyext/tests/test_demo.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 import nose.tools as nt
 from IPython.testing import tools as tt
 
-from ipyext.demo import notebook_demo, Frontend, GithubURLBackend
+from ipyext.demo import demo, Frontend, GithubURLBackend
 import ipyext.demo
 
 class TestFrontent(Frontend):
@@ -37,19 +37,19 @@ def test_github_backend():
     # no full test of teh content as I don't want to rely on github and matplotlib for this...
 
     with tt.AssertPrints("Unknown github demo source"):
-        notebook_demo("<gh_not_xxx_existing>")
+        demo("<gh_not_xxx_existing>")
 
 
 def test_python_backend():
 
     with tt.AssertPrints("has no demos available."):
-        notebook_demo(nt)
+        demo(nt)
 
     with tt.AssertPrints("has the following demo(s) available:"):
-        notebook_demo(ipyext.demo)
+        demo(ipyext.demo)
 
     with tt.AssertPrints("demo_example"):
-        notebook_demo(ipyext.demo)
+        demo(ipyext.demo)
 
     exp = [
         "markdown",
@@ -85,7 +85,7 @@ def test_python_backend():
         ]
 
     fe = TestFrontent(exp)
-    notebook_demo(ipyext.demo.demo_example, frontend=fe)
+    demo(ipyext.demo.demo_example, frontend=fe)
 
 if __name__ == '__main__':
     import nose

--- a/ipyext/tests/test_demo.py
+++ b/ipyext/tests/test_demo.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""Tests for the demo mode.
+"""
+
+from __future__ import absolute_import
+
+import nose.tools as nt
+from IPython.testing import tools as tt
+
+from ipyext.demo import notebook_demo, Frontend, GithubURLBackend
+import ipyext.demo
+
+class TestFrontent(Frontend):
+
+    def __init__(self, expected):
+        self.buffer = []
+        self.expected = expected
+
+    def _publish(self):
+        """Publishes the content of the demo to the frontend"""
+        nt.maxDiff = None
+        nt.assert_list_equal(self.buffer, self.expected)
+
+    def _build(self, cells):
+        """Builds the to be published content from the cells"""
+        for cell in cells:
+            self.buffer.append(cell['cell_type'])
+            self.buffer.append(cell['source'])
+
+def test_github_backend():
+    # this only works if we have access to the internet...
+    backend = GithubURLBackend()
+    typ, content = backend.get("<gh_matplotlib>")
+    nt.assert_equal(typ, "toc")
+    typ, content = backend.get("<gh_matplotlib>/style_sheets/plot_grayscale.py")
+    nt.assert_equal(typ, "cells")
+    # no full test of teh content as I don't want to rely on github and matplotlib for this...
+
+    with tt.AssertPrints("Unknown github demo source"):
+        notebook_demo("<gh_not_xxx_existing>")
+
+
+def test_python_backend():
+
+    with tt.AssertPrints("has no demos available."):
+        notebook_demo(nt)
+
+    with tt.AssertPrints("has the following demo(s) available:"):
+        notebook_demo(ipyext.demo)
+
+    with tt.AssertPrints("demo_example"):
+        notebook_demo(ipyext.demo)
+
+    exp = [
+        "markdown",
+        "\n".join([
+            "## Comments",
+            "Comments are interpreted as markdown syntax, removing the initial `# `.",
+            "If a comment starts only as `#` it is interpreted as a comment, which will",
+            "end up together with the code."
+            ]),
+        "code",
+        "\n".join([
+            '#change your name:',
+            'name = "Jan"',
+            'print("Hello {0}!".format(name))'
+            ]),
+        "markdown",
+        "\n".join([
+            "## Magics",
+            "Using magics would result in not compiling code, so magics have to be commented out.",
+            "The demo will remove the comment and insert it into the cell as code."
+            ]),
+        "code",
+        "\n".join([
+            "%%time",
+            "_sum = 0",
+            "for x in range(10000):",
+            "    _sum += x"
+            ]),
+        "markdown",
+        "Print the sum:",
+        "code",
+        "print(_sum)\n"
+        ]
+
+    fe = TestFrontent(exp)
+    notebook_demo(ipyext.demo.demo_example, frontend=fe)
+
+if __name__ == '__main__':
+    import nose
+
+    nose.runmodule(argv=[__file__, '-vs', '-x'],# '--pdb', '--pdb-failure'],
+                   # '--with-coverage', '--cover-package=pandas.core'],
+                   exit=False)


### PR DESCRIPTION
Builds new notebook cells from the source of a function:

Example:

```
from ipyext.demo import demo
import ipyext.demo
# ---
demo(ipyext.demo)
# ---
demo(ipyext.demo.demo_example)
```

Closes: https://github.com/ipython-contrib/IPython-extensions/issues/13

**Todo**
- [x] write some tests for the ipython frontend
- [x] `demo("<gh_matplotlib>/")` -> prints the wrong thing...
- [x] write docs...
- [ ] How to format github examples to get them split into multiple cells? Look at some more matplotlib examples...
- [x] Use the events: `get_ipython().events.register("post_run_cell", self.method)`, see here:  https://github.com/FrancescAlted/ipython_memwatcher/blob/master/ipython_memwatcher/memwatcher.py#L47
